### PR TITLE
Replace bad arithmetic for ldbms_tnt_select limit parameter

### DIFF
--- a/ocelotgui.cpp
+++ b/ocelotgui.cpp
@@ -16893,7 +16893,7 @@ int MainWindow::tarantool_real_query(const char *dbms_query,
 
   if (statement_type == TOKEN_KEYWORD_SELECT)
   {
-    lmysql->ldbms_tnt_select(tnt[connection_number], spaceno, 0, (2^32) - 1, 0, iterator_type, tuple);
+    lmysql->ldbms_tnt_select(tnt[connection_number], spaceno, 0, UINT32_MAX, 0, iterator_type, tuple);
     tarantool_flush_and_save_reply(connection_number);
     if (tarantool_errno[connection_number] != 0) return tarantool_errno[connection_number];
     /* The return should be an array of arrays of scalars. */


### PR DESCRIPTION
Prompted by the below compiler warning, this PR replaces `(2^32)-1`, which evaluates to 33, with `UINT32_MAX` which is equivalent to `(1LL<<32)-1` or `pow(2,32)-1` or 4294967295. This value is being used as the `limit` parameter to `tnt_select`, further explained at https://tarantool.github.io/tarantool-c/request.html#c.tnt_select as follows

> `limit` is the number of requests to gather. For gathering all results, set `limit` = `UINT32_MAX`.

I will also be opening issues or PRs or sending feedback for other instances of this mistake, which seem to have proliferated from a bad example in the tarantool "book" at https://www.tarantool.io/en/doc/1.10/book/connectors/#example-2

```
[ 80%] Building CXX object CMakeFiles/ocelotgui.dir/ocelotgui.cpp.o
/home/sparr/src/ocelotgui/ocelotgui.cpp: In member function ‘int MainWindow::tarantool_real_query(const char*, long unsigned int, unsigned int, unsigned int, unsigned int, const QString*)’:
/home/sparr/src/ocelotgui/ocelotgui.cpp:16896:68: warning: result of ‘2^32’ is 34; did you mean ‘1LL << 32’? [-Wxor-used-as-pow]
16896 |     lmysql->ldbms_tnt_select(tnt[connection_number], spaceno, 0, (2^32) - 1, 0, iterator_type, tuple);
      |                                                                    ^
      |                                                                   --
      |                                                                   1LL<<
/home/sparr/src/ocelotgui/ocelotgui.cpp:16896:67: note: you can silence this warning by using a hexadecimal constant (0x2 rather than 2)
16896 |     lmysql->ldbms_tnt_select(tnt[connection_number], spaceno, 0, (2^32) - 1, 0, iterator_type, tuple);
      |                                                                   ^
      |                                                                   0x2
```